### PR TITLE
Update stopMonitoring return value

### DIFF
--- a/api.ts
+++ b/api.ts
@@ -62,8 +62,9 @@ export interface SerialMonitorApi extends vscode.Disposable {
    *
    * This will search for the window that is actively monitoring the requested port, if it's present, and stop the monitoring.
    * @param portName The port name to stop monitoring.
+   * @returns True if a `portName` was being monitored and was stopped. Otherwise, returns false.
    */
-  stopMonitoringPort(portName: string): Promise<void>;
+  stopMonitoringPort(portName: string): Promise<boolean>;
 
   /**
    * Clear the output of all of the serial monitor webviews.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@microsoft/vscode-serial-monitor-api",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "description": "Public API for vscode-serial-monitor",
   "keywords": [
     "vscode",


### PR DESCRIPTION
Adds a boolean that the consumer than use to know whether closing was "necessary". If an active monitoring session of `portName` was present, it will close and return `true`. 

Otherwise, false. This will help support restoration. 