### PR TITLE
add manually invoked workflow for closing fixed-pending-release

### DIFF
--- a/.github/workflows/close-fixed-pending-release.yml
+++ b/.github/workflows/close-fixed-pending-release.yml
@@ -1,0 +1,19 @@
+name: Closed fixed-pending-release issues
+on:
+    workflow_dispatch:
+        inputs:
+            message:
+                description: "The message to be commented on issues that are closed due to being fixed."
+                required: true
+
+jobs:
+    close_fixed_pending_release:
+        runs-on: ubuntu-latest
+        steps:
+            - name: Close issues marked 'fixed-pending-release'
+              uses: gcampbell-msft/fixed-pending-release@0.0.11
+              with:
+                token: ${{ secrets.GITHUB_TOKEN }}
+                label: fixed-pending-release
+                message: ${{ inputs.message }}
+                isExternalRelease: true

--- a/.github/workflows/close-fixed-pending-release.yml
+++ b/.github/workflows/close-fixed-pending-release.yml
@@ -11,7 +11,7 @@ jobs:
         runs-on: ubuntu-latest
         steps:
             - name: Close issues marked 'fixed-pending-release'
-              uses: gcampbell-msft/fixed-pending-release@0.0.11
+              uses: gcampbell-msft/fixed-pending-release@0.0.12
               with:
                 token: ${{ secrets.GITHUB_TOKEN }}
                 label: fixed-pending-release


### PR DESCRIPTION
This is a PR that adds a github workflow that can be manually run to close fixed-pending-release issues. It should only be ran when a new release is published.